### PR TITLE
Bug 1237325 - Update to treeherder-client v2.0.1 and pin deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
 boto==2.38.0
 mozinfo==0.8
-treeherder-client==1.8.0
+treeherder-client==2.0.1
+
+# Required by treeherder-client
+mohawk==0.3.0
+requests==2.9.1
+requests-hawk==1.0.0
+six==1.10.0


### PR DESCRIPTION
In order to avoid breakage from updates to sub-dependencies, they have been pinned too :-)
